### PR TITLE
Reflect the gleam/http changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A Gleam HTTP service adapter for the Elli web server.
 ```rust
 import gleam/erlang
 import gleam/http/elli
-import gleam/http.{Request, Response}
+import gleam/http/response.{Response}
+import gleam/http/request.{Request}
 import gleam/bit_builder.{BitBuilder}
 
 // Define a HTTP service
@@ -13,9 +14,9 @@ import gleam/bit_builder.{BitBuilder}
 pub fn my_service(req: Request(BitString)) -> Response(BitBuilder) {
   let body = bit_builder.from_string("Hello, world!")
 
-  http.response(200)
-  |> http.prepend_resp_header("made-with", "Gleam")
-  |> http.set_resp_body(body)
+  response.new(200)
+  |> response.prepend_header("made-with","Gleam")
+  |> response.set_body(body)
 }
 
 // Start it on port 3000!


### PR DESCRIPTION
The README example didn't compile. With this, it should. (Hopefully I didn't miss other changes)