### PR TITLE
Notify the OTP logger on service errors

### DIFF
--- a/src/gleam_elli_native.erl
+++ b/src/gleam_elli_native.erl
@@ -44,5 +44,5 @@ get_host(Request) ->
         Host when is_binary(Host) -> Host
     end.
 
-mask(Request) ->
-    Request#req{headers = [], body = <<>>}.
+mask(#req{path = Path}) ->
+    #req{path = Path}.

--- a/src/gleam_elli_native.erl
+++ b/src/gleam_elli_native.erl
@@ -9,24 +9,24 @@ handle(Req, Handler) ->
 
 handle_event(request_error, [Request, Error, Stacktrace], _) ->
     ?LOG_ERROR(#{
-        <<"message">> => <<"request handler had a runtime error">>,
-        <<"error">> => Error,
-        <<"request">> => Request,
-        <<"stacktrace">> => Stacktrace
+        message => <<"request handler had a runtime error">>,
+        error => Error,
+        request => Request,
+        stacktrace => Stacktrace
     });
 handle_event(request_throw, [Request, Exception, Stacktrace], _) ->
     ?LOG_ERROR(#{
-        <<"message">> => <<"request handler threw an exception">>,
-        <<"error">> => Exception,
-        <<"request">> => Request,
-        <<"stacktrace">> => Stacktrace
+        message => <<"request handler threw an exception">>,
+        error => Exception,
+        request => Request,
+        stacktrace => Stacktrace
     });
 handle_event(request_exit, [Request, Exit, Stacktrace], _) ->
     ?LOG_ERROR(#{
-        <<"message">> => <<"request handler exited">>,
-        <<"error">> => Exit,
-        <<"request">> => Request,
-        <<"stacktrace">> => Stacktrace
+        message => <<"request handler exited">>,
+        error => Exit,
+        request => Request,
+        stacktrace => Stacktrace
     });
 handle_event(_, _, _) ->
     ok.

--- a/src/gleam_elli_native.erl
+++ b/src/gleam_elli_native.erl
@@ -1,6 +1,7 @@
 -module(gleam_elli_native).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("elli/include/elli.hrl").
 
 -export([handle/2, handle_event/3, await_shutdown/1, get_host/1]).
 
@@ -11,21 +12,21 @@ handle_event(request_error, [Request, Error, Stacktrace], _) ->
     ?LOG_ERROR(#{
         message => <<"request handler had a runtime error">>,
         error => Error,
-        request => Request,
+        request => mask(Request),
         stacktrace => Stacktrace
     });
 handle_event(request_throw, [Request, Exception, Stacktrace], _) ->
     ?LOG_ERROR(#{
         message => <<"request handler threw an exception">>,
         error => Exception,
-        request => Request,
+        request => mask(Request),
         stacktrace => Stacktrace
     });
 handle_event(request_exit, [Request, Exit, Stacktrace], _) ->
     ?LOG_ERROR(#{
         message => <<"request handler exited">>,
         error => Exit,
-        request => Request,
+        request => mask(Request),
         stacktrace => Stacktrace
     });
 handle_event(_, _, _) ->
@@ -42,3 +43,6 @@ get_host(Request) ->
         undefined -> <<>>;
         Host when is_binary(Host) -> Host
     end.
+
+mask(Request) ->
+    Request#req{headers = [], body = <<>>}.

--- a/src/gleam_elli_native.erl
+++ b/src/gleam_elli_native.erl
@@ -51,13 +51,4 @@ path(#req{path = Path}) ->
     erlang:iolist_to_binary(["/"] ++ lists:join("/", Path)).
 
 method(#req{method = Method}) ->
-    case Method of
-        'OPTIONS' -> options;
-        'GET' -> get;
-        'HEAD' -> head;
-        'POST' -> post;
-        'PUT' -> put;
-        'DELETE' -> delete;
-        'TRACE' -> trace;
-        _ -> Method
-    end.
+    Method.

--- a/src/gleam_elli_native.erl
+++ b/src/gleam_elli_native.erl
@@ -1,10 +1,33 @@
 -module(gleam_elli_native).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([handle/2, handle_event/3, await_shutdown/1, get_host/1]).
 
 handle(Req, Handler) ->
     Handler(Req).
 
+handle_event(request_error, [Request, Error, Stacktrace], _) ->
+    ?LOG_ERROR(#{
+        <<"message">> => <<"request handler had a runtime error">>,
+        <<"error">> => Error,
+        <<"request">> => Request,
+        <<"stacktrace">> => Stacktrace
+    });
+handle_event(request_throw, [Request, Exception, Stacktrace], _) ->
+    ?LOG_ERROR(#{
+        <<"message">> => <<"request handler threw an exception">>,
+        <<"error">> => Exception,
+        <<"request">> => Request,
+        <<"stacktrace">> => Stacktrace
+    });
+handle_event(request_exit, [Request, Exit, Stacktrace], _) ->
+    ?LOG_ERROR(#{
+        <<"message">> => <<"request handler exited">>,
+        <<"error">> => Exit,
+        <<"request">> => Request,
+        <<"stacktrace">> => Stacktrace
+    });
 handle_event(_, _, _) ->
     ok.
 

--- a/src/gleam_elli_native.erl
+++ b/src/gleam_elli_native.erl
@@ -12,21 +12,24 @@ handle_event(request_error, [Request, Error, Stacktrace], _) ->
     ?LOG_ERROR(#{
         message => <<"request handler had a runtime error">>,
         error => Error,
-        request => mask(Request),
+        method => method(Request),
+        path => path(Request),
         stacktrace => Stacktrace
     });
 handle_event(request_throw, [Request, Exception, Stacktrace], _) ->
     ?LOG_ERROR(#{
         message => <<"request handler threw an exception">>,
         error => Exception,
-        request => mask(Request),
+        method => method(Request),
+        path => path(Request),
         stacktrace => Stacktrace
     });
 handle_event(request_exit, [Request, Exit, Stacktrace], _) ->
     ?LOG_ERROR(#{
         message => <<"request handler exited">>,
         error => Exit,
-        request => mask(Request),
+        method => method(Request),
+        path => path(Request),
         stacktrace => Stacktrace
     });
 handle_event(_, _, _) ->
@@ -44,5 +47,17 @@ get_host(Request) ->
         Host when is_binary(Host) -> Host
     end.
 
-mask(#req{path = Path}) ->
-    #req{path = Path}.
+path(#req{path = Path}) ->
+    erlang:iolist_to_binary(["/"] ++ lists:join("/", Path)).
+
+method(#req{method = Method}) ->
+    case Method of
+        'OPTIONS' -> options;
+        'GET' -> get;
+        'HEAD' -> head;
+        'POST' -> post;
+        'PUT' -> put;
+        'DELETE' -> delete;
+        'TRACE' -> trace;
+        _ -> Method
+    end.

--- a/test/elli_logging_test_ffi.erl
+++ b/test/elli_logging_test_ffi.erl
@@ -1,0 +1,70 @@
+-module(elli_logging_test_ffi).
+
+%% Test API
+-export([
+    bad_service/1,
+    start_log_spy/1,
+    silence_default_handler/0,
+    get_spied_reports/1
+]).
+
+%% Callbacks
+-export([
+    log/2,
+    spy_loop/1
+]).
+
+bad_service(Request) ->
+    {request, _, _, _, _, _, _, Path, {some, <<"message=", Message/binary>>}} = Request,
+    case Path of
+        <<"/throw">> -> throw(Message);
+        <<"/error">> -> error(Message);
+        <<"/exit">> -> exit(Message)
+    end.
+
+%% A spy seemed like the easiest way to test the logging,
+%% and implementing in Erlang was simpler than in Gleam.
+start_log_spy(IdBinary) ->
+    HandlerId = binary_to_atom(IdBinary, utf8),
+    register(HandlerId, spawn(?MODULE, spy_loop, [HandlerId])),
+    logger:add_handler(HandlerId, ?MODULE, #{}).
+
+%% By default the logger will print stuff to the console,
+%% we don't need that in tests.
+silence_default_handler() ->
+    logger:remove_handler(default).
+
+get_spied_reports(IdBinary)->
+    Id = binary_to_atom(IdBinary, utf8),
+    Pid = whereis(Id),
+    Pid ! {get_log, self()},
+    receive
+        {log, LogEvents} ->
+            lists:filtermap(
+                fun
+                    (#{ level := Level, msg := {report, Report}}) ->
+                        %% massage to make it easier to use in tests
+                        {true, Report#{<<"level">> => atom_to_binary(Level)}};
+                    (_) ->
+                        false
+                end,
+                LogEvents
+            )
+    end.
+
+log(LogEvent, Config) ->
+    Id = maps:get(id, Config),
+    Pid = whereis(Id),
+    Pid ! {log, LogEvent}.
+
+spy_loop(Id) ->
+    spy_loop(Id, []).
+
+spy_loop(Id, LogEvents) ->
+    receive
+        {log, LogEvent} ->
+            spy_loop(Id, [LogEvent | LogEvents]);
+        {get_log, Pid} ->
+            Pid ! {log, lists:reverse(LogEvents)},
+            spy_loop(Id, LogEvents)
+    end.

--- a/test/elli_logging_test_ffi.erl
+++ b/test/elli_logging_test_ffi.erl
@@ -5,6 +5,7 @@
     bad_service/1,
     start_log_spy/1,
     silence_default_handler/0,
+    as_request/1,
     get_spied_reports/1
 ]).
 
@@ -51,6 +52,12 @@ get_spied_reports(IdBinary)->
                 LogEvents
             )
     end.
+
+as_request({req, Method, _, _, _, Path, _, _, _, Headers, Body, _, _, _}) ->
+    %% not all fields are used in the tests
+    {ok, {request, Method, Headers, Body, x, x, x, lists:join(<<"/">>, Path), x}};
+as_request(_) ->
+    {error, [{decode_error, <<"a request tuple">>, <<"something else">>, []}]}.
 
 log(LogEvent, Config) ->
     Id = maps:get(id, Config),

--- a/test/elli_logging_test_ffi.erl
+++ b/test/elli_logging_test_ffi.erl
@@ -54,8 +54,9 @@ get_spied_reports(IdBinary)->
     end.
 
 as_request({req, Method, _, _, _, Path, _, _, _, Headers, Body, _, _, _}) ->
+    BinaryPath = iolist_to_binary(lists:join(<<"/">>, [<<"">> | Path])),
     %% not all fields are used in the tests
-    {ok, {request, Method, Headers, Body, x, x, x, lists:join(<<"/">>, Path), x}};
+    {ok, {request, Method, Headers, Body, x, x, x, BinaryPath, x}};
 as_request(_) ->
     {error, [{decode_error, <<"a request tuple">>, <<"something else">>, []}]}.
 

--- a/test/elli_logging_test_ffi.erl
+++ b/test/elli_logging_test_ffi.erl
@@ -44,7 +44,7 @@ get_spied_reports(IdBinary)->
                 fun
                     (#{ level := Level, msg := {report, Report}}) ->
                         %% massage to make it easier to use in tests
-                        {true, Report#{<<"level">> => atom_to_binary(Level)}};
+                        {true, Report#{level => atom_to_binary(Level)}};
                     (_) ->
                         false
                 end,

--- a/test/elli_logging_test_ffi.erl
+++ b/test/elli_logging_test_ffi.erl
@@ -7,9 +7,6 @@
     bad_service/1,
     start_log_spy/1,
     silence_default_handler/0,
-    path/1,
-    headers/1,
-    body/1,
     get_spied_reports/1
 ]).
 
@@ -49,30 +46,12 @@ get_spied_reports(IdBinary)->
                 fun
                     (#{ level := Level, msg := {report, Report}}) ->
                         %% massage to make it easier to use in tests
-                        {true, Report#{level => atom_to_binary(Level)}};
+                        {true, {atom_to_binary(Level), Report}};
                     (_) ->
                         false
                 end,
                 LogEvents
             )
-    end.
-
-path(#req{path = Path}) ->
-    case Path of
-        undefined -> <<>>;
-        _ -> iolist_to_binary(lists:join(<<"/">>, [<<"">> | Path]))
-    end.
-
-headers(#req{headers = Headers}) ->
-    case Headers of
-        undefined -> [];
-        _ -> Headers
-    end.
-
-body(#req{body = Body}) ->
-    case Body of
-        undefined -> <<>>;
-        _ -> Body
     end.
 
 log(LogEvent, Config) ->

--- a/test/elli_logging_test_ffi.erl
+++ b/test/elli_logging_test_ffi.erl
@@ -7,7 +7,9 @@
     bad_service/1,
     start_log_spy/1,
     silence_default_handler/0,
-    as_request/1,
+    path/1,
+    headers/1,
+    body/1,
     get_spied_reports/1
 ]).
 
@@ -55,12 +57,23 @@ get_spied_reports(IdBinary)->
             )
     end.
 
-as_request(#req{method = Method, path = Path, headers = Headers, body = Body}) ->
-    BinaryPath = iolist_to_binary(lists:join(<<"/">>, [<<"">> | Path])),
-    %% not all fields are used in the tests
-    {ok, {request, Method, Headers, Body, x, x, x, BinaryPath, x}};
-as_request(_) ->
-    {error, [{decode_error, <<"a request tuple">>, <<"something else">>, []}]}.
+path(#req{path = Path}) ->
+    case Path of
+        undefined -> <<>>;
+        _ -> iolist_to_binary(lists:join(<<"/">>, [<<"">> | Path]))
+    end.
+
+headers(#req{headers = Headers}) ->
+    case Headers of
+        undefined -> [];
+        _ -> Headers
+    end.
+
+body(#req{body = Body}) ->
+    case Body of
+        undefined -> <<>>;
+        _ -> Body
+    end.
 
 log(LogEvent, Config) ->
     Id = maps:get(id, Config),

--- a/test/elli_logging_test_ffi.erl
+++ b/test/elli_logging_test_ffi.erl
@@ -1,5 +1,7 @@
 -module(elli_logging_test_ffi).
 
+-include_lib("elli/include/elli.hrl").
+
 %% Test API
 -export([
     bad_service/1,
@@ -53,7 +55,7 @@ get_spied_reports(IdBinary)->
             )
     end.
 
-as_request({req, Method, _, _, _, Path, _, _, _, Headers, Body, _, _, _}) ->
+as_request(#req{method = Method, path = Path, headers = Headers, body = Body}) ->
     BinaryPath = iolist_to_binary(lists:join(<<"/">>, [<<"">> | Path])),
     %% not all fields are used in the tests
     {ok, {request, Method, Headers, Body, x, x, x, BinaryPath, x}};

--- a/test/gleam/http/elli_logging_test.gleam
+++ b/test/gleam/http/elli_logging_test.gleam
@@ -88,9 +88,14 @@ pub fn log_masks_request_headers_test() {
 
   assert [err] = get_spied_reports(spy_name)
 
-  assert Ok(req) = get_request(err, Request)
+  assert Ok(logged_req) = get_request(err, Request)
 
-  req.headers
+  // check that we got the request back
+  logged_req.path
+  |> should.equal("/route/with/no/handler")
+
+  // but without the headers
+  logged_req.headers
   |> should.equal([])
 }
 
@@ -107,9 +112,14 @@ pub fn log_masks_request_body_test() {
 
   assert [err] = get_spied_reports(spy_name)
 
-  assert Ok(req) = get_request(err, Request)
+  assert Ok(logged_req) = get_request(err, Request)
 
-  req.body
+  // check that we got the request back
+  logged_req.path
+  |> should.equal("/route/with/no/handler")
+
+  // but without the body
+  logged_req.body
   |> should.equal(bit_string.from_string(""))
 }
 

--- a/test/gleam/http/elli_logging_test.gleam
+++ b/test/gleam/http/elli_logging_test.gleam
@@ -1,0 +1,95 @@
+import gleam/bit_builder.{BitBuilder}
+import gleam/dynamic.{DecodeError, Dynamic}
+import gleam/hackney
+import gleam/http.{Get}
+import gleam/http/elli
+import gleam/http/request.{Request}
+import gleam/http/response.{Response}
+import gleam/list
+import gleam/map.{Map}
+import gleam/result
+import gleeunit/should
+
+// Using FFI to make crashing in the request handler easy.
+external fn bad_service(request: Request(BitString)) -> Response(BitBuilder) =
+  "elli_logging_test_ffi" "bad_service"
+
+pub fn log_errors_test() {
+  let port = 4711
+  assert Ok(_) = elli.start(bad_service, on_port: port)
+
+  let spy_name = "log_errors_test"
+  start_log_spy(spy_name)
+  silence_default_handler()
+
+  list.each(
+    [
+      make_request(port, "/throw", "throw_value"),
+      make_request(port, "/error", "error_value"),
+      make_request(port, "/exit", "exit_value"),
+    ],
+    fn(req) {
+      assert Ok(resp) = hackney.send(req)
+      assert 500 = resp.status
+      assert "Internal server error" = resp.body
+    },
+  )
+
+  assert [throw, err, exit] = get_spied_reports(spy_name)
+
+  assert Ok("error") = get_string(throw, "level")
+  assert Ok("request handler threw an exception") = get_string(throw, "message")
+  assert Ok("throw_value") = get_string(throw, "error")
+  assert Ok(throw_stack) = list_length(exit, "stacktrace")
+  should.be_true(0 < throw_stack)
+
+  assert Ok("error") = get_string(err, "level")
+  assert Ok("request handler had a runtime error") = get_string(err, "message")
+  assert Ok("error_value") = get_string(err, "error")
+  assert Ok(err_stack) = list_length(exit, "stacktrace")
+  should.be_true(0 < err_stack)
+
+  assert Ok("error") = get_string(exit, "level")
+  assert Ok("request handler exited") = get_string(exit, "message")
+  assert Ok("exit_value") = get_string(exit, "error")
+  assert Ok(exit_stack) = list_length(exit, "stacktrace")
+  should.be_true(0 < exit_stack)
+}
+
+external fn start_log_spy(id: String) -> Nil =
+  "elli_logging_test_ffi" "start_log_spy"
+
+external fn silence_default_handler() -> Nil =
+  "elli_logging_test_ffi" "silence_default_handler"
+
+external fn get_spied_reports(id: String) -> List(Map(String, Dynamic)) =
+  "elli_logging_test_ffi" "get_spied_reports"
+
+fn make_request(port: Int, path: String, message: String) {
+  request.new()
+  |> request.set_method(Get)
+  |> request.set_path(path)
+  |> request.set_query([#("message", message)])
+  |> request.set_host("0.0.0.0")
+  |> request.set_scheme(http.Http)
+  |> request.set_port(port)
+}
+
+fn get_string(
+  report: Map(String, Dynamic),
+  key: String,
+) -> Result(String, List(DecodeError)) {
+  map.get(report, key)
+  |> result.map_error(fn(_) { [] })
+  |> result.then(dynamic.string)
+}
+
+fn list_length(
+  report: Map(String, Dynamic),
+  key: String,
+) -> Result(Int, List(DecodeError)) {
+  map.get(report, key)
+  |> result.map_error(fn(_) { [] })
+  |> result.then(dynamic.shallow_list)
+  |> result.map(list.length)
+}

--- a/test/gleam/http/elli_logging_test.gleam
+++ b/test/gleam/http/elli_logging_test.gleam
@@ -14,45 +14,63 @@ import gleeunit/should
 external fn bad_service(request: Request(BitString)) -> Response(BitBuilder) =
   "elli_logging_test_ffi" "bad_service"
 
-pub fn log_errors_test() {
-  let port = 4711
+pub fn log_throw_test() {
+  let port = 4712
   assert Ok(_) = elli.start(bad_service, on_port: port)
 
-  let spy_name = "log_errors_test"
+  let spy_name = "log_throw_test"
   start_log_spy(spy_name)
   silence_default_handler()
 
-  list.each(
-    [
-      make_request(port, "/throw", "throw_value"),
-      make_request(port, "/error", "error_value"),
-      make_request(port, "/exit", "exit_value"),
-    ],
-    fn(req) {
-      assert Ok(resp) = hackney.send(req)
-      assert 500 = resp.status
-      assert "Internal server error" = resp.body
-    },
-  )
+  make_request(port, "/throw", "throw_value")
+  |> hackney.send
 
-  assert [throw, err, exit] = get_spied_reports(spy_name)
+  assert [throw] = get_spied_reports(spy_name)
 
-  assert Ok("error") = get_string(throw, "level")
-  assert Ok("request handler threw an exception") = get_string(throw, "message")
-  assert Ok("throw_value") = get_string(throw, "error")
-  assert Ok(throw_stack) = list_length(exit, "stacktrace")
+  assert Ok("error") = get_string(throw, Level)
+  assert Ok("request handler threw an exception") = get_string(throw, Message)
+  assert Ok("throw_value") = get_string(throw, Error)
+  assert Ok(throw_stack) = list_length(throw, Stacktrace)
   should.be_true(0 < throw_stack)
+}
 
-  assert Ok("error") = get_string(err, "level")
-  assert Ok("request handler had a runtime error") = get_string(err, "message")
-  assert Ok("error_value") = get_string(err, "error")
-  assert Ok(err_stack) = list_length(exit, "stacktrace")
+pub fn log_error_test() {
+  let port = 4713
+  assert Ok(_) = elli.start(bad_service, on_port: port)
+
+  let spy_name = "log_error_test"
+  start_log_spy(spy_name)
+  silence_default_handler()
+
+  make_request(port, "/error", "error_value")
+  |> hackney.send
+
+  assert [err] = get_spied_reports(spy_name)
+
+  assert Ok("error") = get_string(err, Level)
+  assert Ok("request handler had a runtime error") = get_string(err, Message)
+  assert Ok("error_value") = get_string(err, Error)
+  assert Ok(err_stack) = list_length(err, Stacktrace)
   should.be_true(0 < err_stack)
+}
 
-  assert Ok("error") = get_string(exit, "level")
-  assert Ok("request handler exited") = get_string(exit, "message")
-  assert Ok("exit_value") = get_string(exit, "error")
-  assert Ok(exit_stack) = list_length(exit, "stacktrace")
+pub fn log_exit_test() {
+  let port = 4714
+  assert Ok(_) = elli.start(bad_service, on_port: port)
+
+  let spy_name = "log_exit_test"
+  start_log_spy(spy_name)
+  silence_default_handler()
+
+  make_request(port, "/exit", "exit_value")
+  |> hackney.send
+
+  assert [exit] = get_spied_reports(spy_name)
+
+  assert Ok("error") = get_string(exit, Level)
+  assert Ok("request handler exited") = get_string(exit, Message)
+  assert Ok("exit_value") = get_string(exit, Error)
+  assert Ok(exit_stack) = list_length(exit, Stacktrace)
   should.be_true(0 < exit_stack)
 }
 
@@ -62,7 +80,15 @@ external fn start_log_spy(id: String) -> Nil =
 external fn silence_default_handler() -> Nil =
   "elli_logging_test_ffi" "silence_default_handler"
 
-external fn get_spied_reports(id: String) -> List(Map(String, Dynamic)) =
+type ReportKey {
+  Level
+  Message
+  Error
+  Request
+  Stacktrace
+}
+
+external fn get_spied_reports(id: String) -> List(Map(ReportKey, Dynamic)) =
   "elli_logging_test_ffi" "get_spied_reports"
 
 fn make_request(port: Int, path: String, message: String) {
@@ -76,8 +102,8 @@ fn make_request(port: Int, path: String, message: String) {
 }
 
 fn get_string(
-  report: Map(String, Dynamic),
-  key: String,
+  report: Map(a, Dynamic),
+  key: a,
 ) -> Result(String, List(DecodeError)) {
   map.get(report, key)
   |> result.map_error(fn(_) { [] })
@@ -85,8 +111,8 @@ fn get_string(
 }
 
 fn list_length(
-  report: Map(String, Dynamic),
-  key: String,
+  report: Map(a, Dynamic),
+  key: a,
 ) -> Result(Int, List(DecodeError)) {
   map.get(report, key)
   |> result.map_error(fn(_) { [] })


### PR DESCRIPTION
Why?
-----

This is one way to solve #13.

This solution uses error report maps with binary keys for the relevant fields, but the values are just passed through. I'm not sure there is a more "gleamy" way to do it, or if there should be. Depends on how one would like to use gleam_elli together with other BEAM languages maybe?

Example Log Output
--------------------

```
=ERROR REPORT==== 29-Jan-2023::18:09:04.138192 ===
    <<"message">>: <<"request handler threw an exception">>
    <<"error">>: <<"throw_this_value_please">>
    <<"request">>: {req,'GET',undefined,undefined,undefined,
                        [<<"throw">>],
                        [{<<"message">>,<<"throwing">>}],
                        <<"/throw?message=throw_this_value_please">>,
                        {1,1},
                        [{<<"Content-Length">>,<<"0">>},
                         {<<"Content-Type">>,<<"application/octet-stream">>},
                         {<<"User-Agent">>,<<"hackney/1.18.1">>},
                         {<<"Host">>,<<"0.0.0.0:12496">>}],
                        <<>>,<0.233.0>,
                        {plain,#Port<0.19>},
                        {gleam_elli_native,#Fun<gleam@http@elli.1.4620056>}}
    <<"stacktrace">>: [{elli_test_ffi,bad_service,1,
                           [{file,
                                "build/dev/erlang/gleam_elli/_gleam_artefacts/elli_test_ffi.erl"},
                            {line,33}]},
                       {gleam@http@elli,'-service_to_elli_handler/1-fun-1-',
                           2,
                           [{file,
                                "build/dev/erlang/gleam_elli/_gleam_artefacts/gleam@http@elli.erl"},
                            {line,79}]},
                       {elli_http,execute_callback,1,
                           [{file,
                                "/Users/fabian/code/fabjan/elli/build/dev/erlang/elli/src/elli_http.erl"},
                            {line,287}]},
                       {elli_http,handle_request,4,
                           [{file,
                                "/Users/fabian/code/fabjan/elli/build/dev/erlang/elli/src/elli_http.erl"},
                            {line,104}]},
                       {elli_http,keepalive_loop,5,
                           [{file,
                                "/Users/fabian/code/fabjan/elli/build/dev/erlang/elli/src/elli_http.erl"},
                            {line,71}]},
                       {proc_lib,init_p_do_apply,3,
                           [{file,"proc_lib.erl"},{line,240}]}]
```