### PR TITLE
add install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Install
 
 ```
-gleam add gleam_elli
+gleam add gleam_elli gleam_http
 ```
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Elli
 
+### Install
+
+```
+gleam add gleam_elli
+```
+
+### Example
+
 A Gleam HTTP service adapter for the Elli web server.
 
 ```gleam


### PR DESCRIPTION
I'm a newbie of Gleam, so it took a while to figure out that `gleam/http/elli` is exported from `gleam_elli` package :) because there's also `elli` and `gleam_http` which are not what is needed :)